### PR TITLE
Make GCS and local artifacts consistent

### DIFF
--- a/cdap/resource_gcs_artifact.go
+++ b/cdap/resource_gcs_artifact.go
@@ -32,7 +32,7 @@ var bucketPathRE = regexp.MustCompile(`^gs://(.+)/(.+)$`)
 // store the entire JAR's contents as a string.
 func resourceGCSArtifact() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGCSArtifactCreate,
+		Create: resourceLocalArtifactCreate,
 		Read:   resourceLocalArtifactRead,
 		Delete: resourceLocalArtifactDelete,
 		Exists: resourceLocalArtifactExists,
@@ -40,7 +40,7 @@ func resourceGCSArtifact() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Computed:    true,
+				Required:    true,
 				ForceNew:    true,
 				Description: "The name of the artifact.",
 			},
@@ -53,133 +53,79 @@ func resourceGCSArtifact() *schema.Resource {
 					return defaultNamespace, nil
 				},
 			},
-			"bucket_path": {
+			// Technically, we could omit the version in the API call because CDAP will infer the
+			// version from the jar. However, forcing the user to specify the version makes dealing
+			// with the resource easier because other API calls require it.
+			"version": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Path to GCS bucket object containing the spec, JAR and JSON.",
+				Description: "The version of the artifact. Must match the version in the JAR manifest.",
 			},
-			"version": {
+			"jar_binary_path": {
 				Type:        schema.TypeString,
-				Computed:    true,
+				Required:    true,
 				ForceNew:    true,
-				Description: "The version of the artifact.",
+				Description: "The GCS path to the JAR binary for the artifact.",
+			},
+			"json_config_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The GCS path to the JSON config of the artifact.",
 			},
 		},
 	}
-}
-
-type artifactSpec struct {
-	Actions []*action `json:"actions"`
-}
-type action struct {
-	Type string `json:"type"`
-	Args []*struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
-	} `json:"arguments"`
 }
 
 func resourceGCSArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	ctx := context.Background()
 	config := m.(*Config)
 
-	// matches is in the form [matched substring, bucket name, object name].
-	matches := bucketPathRE.FindStringSubmatch(d.Get("bucket_path").(string))
-	if len(matches) != 3 {
-		return fmt.Errorf("unexpected bucket path: got %q submatches, want 3", len(matches))
-	}
-
-	bucketName, objectPath := matches[1], matches[2]
-	bucket := config.storageClient.Bucket(bucketName)
-	data, err := loadDataFromGCS(ctx, bucket, objectPath)
+	a, err := loadGCSArtifact(ctx, d, config.storageClient)
 	if err != nil {
 		return err
 	}
 
-	addr := urlJoin(config.host, "/v3/namespaces", d.Get("namespace").(string), "/artifacts", data.name)
-
-	if err := uploadJar(config.client, addr, data); err != nil {
-		return err
-	}
-	if err := uploadProps(config.client, addr, data); err != nil {
+	if err := uploadArtifact(config, d, a); err != nil {
 		return err
 	}
 
-	d.Set("name", data.name)
-	d.Set("version", data.version)
-	d.SetId(data.name)
+	d.SetId(a.name)
 	return nil
 }
 
-func loadDataFromGCS(ctx context.Context, bucket *storage.BucketHandle, objectPath string) (*artifactData, error) {
-	specObj := bucket.Object(urlJoin(objectPath, "spec.json"))
-	b, err := readObject(ctx, specObj)
+func loadGCSArtifact(ctx context.Context, d *schema.ResourceData, storageClient *storage.Client) (*artifact, error) {
+	jar, err := readObject(ctx, storageClient, d.Get("jar_binary_path").(string))
 	if err != nil {
 		return nil, err
 	}
 
-	spec := new(artifactSpec)
-	if err := json.Unmarshal(b, spec); err != nil {
+	confb, err := readObject(ctx, storageClient, d.Get("json_config_path").(string))
+	if err != nil {
+		return nil, err
+	}
+	conf := new(artifactConfig)
+	if err := json.Unmarshal(confb, conf); err != nil {
 		return nil, err
 	}
 
-	if len(spec.Actions) != 1 {
-		return nil, fmt.Errorf("only 1 action is currently supported, got %v", len(spec.Actions))
-	}
-	action := spec.Actions[0]
-	if got, want := action.Type, "one_step_deploy_plugin"; got != want {
-		return nil, fmt.Errorf("only action of type %q is currently supported, got %q", want, got)
-	}
-	return loadDataFromAction(ctx, bucket, objectPath, action)
+	return &artifact{
+		name:    d.Get("name").(string),
+		version: d.Get("version").(string),
+		jar:     jar,
+		config:  conf,
+	}, nil
 }
 
-func loadDataFromAction(ctx context.Context, bucket *storage.BucketHandle, objectPath string, action *action) (*artifactData, error) {
-	wantArgs := map[string]bool{
-		"name":    true,
-		"version": true,
-		"config":  true,
-		"jar":     true,
+func readObject(ctx context.Context, storageClient *storage.Client, path string) ([]byte, error) {
+	// matches is in the form [matched substring, bucket name, object name].
+	matches := bucketPathRE.FindStringSubmatch(path)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("unexpected bucket path: got %q submatches, want 3", len(matches))
 	}
-
-	data := &artifactData{}
-	for _, arg := range action.Args {
-		switch arg.Name {
-		case "name":
-			delete(wantArgs, "name")
-			data.name = arg.Value
-		case "version":
-			delete(wantArgs, "version")
-			data.version = arg.Value
-		case "config":
-			delete(wantArgs, "config")
-			confObj := bucket.Object(urlJoin(objectPath, arg.Value))
-			b, err := readObject(ctx, confObj)
-			if err != nil {
-				return nil, err
-			}
-			data.config = new(artifactConfig)
-			if err := json.Unmarshal(b, data.config); err != nil {
-				return nil, err
-			}
-		case "jar":
-			delete(wantArgs, "jar")
-			jarObj := bucket.Object(urlJoin(objectPath, arg.Value))
-			b, err := readObject(ctx, jarObj)
-			if err != nil {
-				return nil, err
-			}
-			data.jar = b
-		}
-	}
-
-	if len(wantArgs) != 0 {
-		return nil, fmt.Errorf("failed to find artifact fields %v", wantArgs)
-	}
-	return data, nil
-}
-
-func readObject(ctx context.Context, obj *storage.ObjectHandle) ([]byte, error) {
+	bucketName, objectPath := matches[1], matches[2]
+	obj := storageClient.Bucket(bucketName).Object(objectPath)
 	r, err := obj.NewReader(ctx)
 	if err != nil {
 		return nil, err

--- a/cdap/resource_gcs_artifact.go
+++ b/cdap/resource_gcs_artifact.go
@@ -32,7 +32,7 @@ var bucketPathRE = regexp.MustCompile(`^gs://(.+)/(.+)$`)
 // store the entire JAR's contents as a string.
 func resourceGCSArtifact() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceLocalArtifactCreate,
+		Create: resourceGCSArtifactCreate,
 		Read:   resourceLocalArtifactRead,
 		Delete: resourceLocalArtifactDelete,
 		Exists: resourceLocalArtifactExists,

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -24,6 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// resourceGCSArtifact supports deploying an artifact by providing a local filepath.
+// We need to use references like GCS or filepaths to avoid needing to pass and
+// store the entire JAR's contents as a string.
 func resourceLocalArtifact() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLocalArtifactCreate,
@@ -60,16 +63,28 @@ func resourceLocalArtifact() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The path to the JAR binary for the artifact.",
+				Description: "The local path to the JAR binary for the artifact.",
 			},
 			"json_config_path": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "THe path to the JSON config of the artifact.",
+				Description: "The local path to the JSON config of the artifact.",
 			},
 		},
 	}
+}
+
+type artifact struct {
+	name    string
+	version string
+	config  *artifactConfig
+	jar     []byte
+}
+
+type artifactConfig struct {
+	Properties map[string]string `json:"properties"`
+	Parents    []string          `json:"parents"`
 }
 
 func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
@@ -78,38 +93,45 @@ func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	// management to account for the facdt that setting properties may fail
 	// because uploading a jar can occur multiple times without error.
 	config := m.(*Config)
-	data, err := initArtifactData(d)
+	a, err := loadLocalArtifact(d)
 	if err != nil {
 		return err
 	}
-	addr := urlJoin(config.host, "/v3/namespaces", d.Get("namespace").(string), "/artifacts", data.name)
-	if err := uploadJar(config.client, addr, data); err != nil {
-		return err
-	}
-	if err := uploadProps(config.client, addr, data); err != nil {
-		return err
-	}
-	d.SetId(data.name)
+	uploadArtifact(config, d, a)
+	d.SetId(a.name)
 	return nil
 }
 
-func uploadJar(client *http.Client, addr string, d *artifactData) error {
-	req, err := http.NewRequest(http.MethodPost, addr, bytes.NewReader(d.jar))
+func uploadArtifact(config *Config, rd *schema.ResourceData, a *artifact) error {
+	addr := urlJoin(config.host, "/v3/namespaces", rd.Get("namespace").(string), "/artifacts", a.name)
+
+	if err := uploadJar(config.client, addr, a); err != nil {
+		return err
+	}
+	if err := uploadProps(config.client, addr, a); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func uploadJar(client *http.Client, addr string, a *artifact) error {
+	req, err := http.NewRequest(http.MethodPost, addr, bytes.NewReader(a.jar))
 	if err != nil {
 		return err
 	}
 	req.Header = map[string][]string{}
-	req.Header.Add("Artifact-Version", d.version)
-	req.Header.Add("Artifact-Extends", strings.Join(d.config.Parents, "/"))
+	req.Header.Add("Artifact-Version", a.version)
+	req.Header.Add("Artifact-Extends", strings.Join(a.config.Parents, "/"))
 	if _, err := httpCall(client, req); err != nil {
 		return err
 	}
 	return nil
 }
 
-func uploadProps(client *http.Client, artifactAddr string, d *artifactData) error {
-	addr := urlJoin(artifactAddr, "/versions", d.version, "/properties")
-	b, err := json.Marshal(d.config.Properties)
+func uploadProps(client *http.Client, artifactAddr string, a *artifact) error {
+	addr := urlJoin(artifactAddr, "/versions", a.version, "/properties")
+	b, err := json.Marshal(a.config.Properties)
 	if err != nil {
 		return err
 	}
@@ -124,46 +146,27 @@ func uploadProps(client *http.Client, artifactAddr string, d *artifactData) erro
 	return nil
 }
 
-type artifactData struct {
-	name    string
-	version string
-	config  *artifactConfig
-	jar     []byte
-}
-
-func initArtifactData(d *schema.ResourceData) (*artifactData, error) {
+func loadLocalArtifact(d *schema.ResourceData) (*artifact, error) {
 	jar, err := ioutil.ReadFile(d.Get("jar_binary_path").(string))
 	if err != nil {
 		return nil, err
 	}
-	ac, err := readArtifactConfig(d.Get("json_config_path").(string))
+
+	confb, err := ioutil.ReadFile(d.Get("json_config_path").(string))
 	if err != nil {
 		return nil, err
 	}
-	name := d.Get("name").(string)
-	return &artifactData{
-		name:    name,
+	conf := new(artifactConfig)
+	if err := json.Unmarshal(confb, conf); err != nil {
+		return nil, err
+	}
+
+	return &artifact{
+		name:    d.Get("name").(string),
 		version: d.Get("version").(string),
-		config:  ac,
+		config:  conf,
 		jar:     jar,
 	}, nil
-}
-
-type artifactConfig struct {
-	Properties map[string]string `json:"properties"`
-	Parents    []string          `json:"parents"`
-}
-
-func readArtifactConfig(fileName string) (*artifactConfig, error) {
-	b, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		return nil, err
-	}
-	var c artifactConfig
-	if err := json.Unmarshal(b, &c); err != nil {
-		return nil, err
-	}
-	return &c, nil
 }
 
 func resourceLocalArtifactRead(d *schema.ResourceData, m interface{}) error {

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-// resourceGCSArtifact supports deploying an artifact by providing a local filepath.
+// resourceLocalArtifact supports deploying an artifact by providing a local filepath.
 // We need to use references like GCS or filepaths to avoid needing to pass and
 // store the entire JAR's contents as a string.
 func resourceLocalArtifact() *schema.Resource {

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -97,7 +97,9 @@ func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	uploadArtifact(config, d, a)
+	if err := uploadArtifact(config, d, a); err != nil {
+		return err
+	}
 	d.SetId(a.name)
 	return nil
 }

--- a/docs/r/cdap_gcs_artifact.md
+++ b/docs/r/cdap_gcs_artifact.md
@@ -5,12 +5,16 @@
 
 The following fields are supported:
 
-* bucket_path
+* jar_binary_path
   (Required):
-  Path to GCS bucket object containing the spec, JAR and JSON.
+  The GCS path to the JAR binary for the artifact.
+
+* json_config_path
+  (Required):
+  The GCS path to the JSON config of the artifact.
 
 * name
-  (Computed):
+  (Required):
   The name of the artifact.
 
 * namespace
@@ -18,6 +22,6 @@ The following fields are supported:
   The name of the namespace in which this resource belongs. If not provided, the default namespace is used.
 
 * version
-  (Computed):
-  The version of the artifact.
+  (Required):
+  The version of the artifact. Must match the version in the JAR manifest.
 

--- a/docs/r/cdap_local_artifact.md
+++ b/docs/r/cdap_local_artifact.md
@@ -7,11 +7,11 @@ The following fields are supported:
 
 * jar_binary_path
   (Required):
-  The path to the JAR binary for the artifact.
+  The local path to the JAR binary for the artifact.
 
 * json_config_path
   (Required):
-  THe path to the JSON config of the artifact.
+  The local path to the JSON config of the artifact.
 
 * name
   (Required):

--- a/examples/artifact/main.tf
+++ b/examples/artifact/main.tf
@@ -21,6 +21,8 @@ resource "google_data_fusion_instance" "instance" {
   region = "us-central1"
   type = "BASIC"
   project = "example-project"
+
+  # Use Healthcare Hub.
   options = {
     "market.base.url": "https://storage.googleapis.com/${local.hub_bucket}"
   }
@@ -35,13 +37,16 @@ provider "cdap" {
 
 # Option 1: Path in GCS bucket containing the spec, JAR and JSON config.
 resource "cdap_gcs_artifact" "gcs_whistler_1_0_0" {
-  bucket_path = "gs://${local.hub_bucket}/packages/healthcare-mapping-transform/1.0.0"
+  name = "whistler-transform"
+  version = "1.0.0"
+  json_config_path = "gs://${local.hub_bucket}/packages/healthcare-mapping-transform/1.0.0/whistler-transform-1.0.0.json"
+  jar_binary_path = "gs://${local.hub_bucket}/packages/healthcare-mapping-transform/1.0.0/whistler-transform-1.0.0.jar"
 }
 
 # Option 2: Download or compile JAR and JSON config and pass as local files.
 resource "cdap_local_artifact" "local_whistler_1_0_0" {
   name = "whistler-transform"
   version = "1.0.0"
-  json_config)path = "./TODO/whistler-transform-1.0.0.json"
+  json_config_path = "./TODO/whistler-transform-1.0.0.json"
   jar_binary_path = "./TODO/whistler-transform-1.0.0.jar"
 }

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=


### PR DESCRIPTION
The API of the gcs artifact was a bit confusing and inconsistent with the local. This makes them the same and also aligns the code to be nearly identical apart from just loading files from GCS instead of local FS.