### PR TITLE
Revert "add health check"

### DIFF
--- a/cdap/provider.go
+++ b/cdap/provider.go
@@ -72,7 +72,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 			TokenType:   "Bearer",
 		}))
 	}
-	httpClient.Timeout = 30 * time.Minute
+	httpClient.Timeout = 5 * time.Minute
 
 	storageClient, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadOnly))
 	if err != nil {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/terraform-provider-cdap#44

This causes plans to fail when the instance isnt running. Going to reimplement either in this provider or GCP until CDF fixes it.