### PR TITLE
set terraform resource id after artifact is created

### DIFF
--- a/cdap/resource_gcs_artifact.go
+++ b/cdap/resource_gcs_artifact.go
@@ -86,13 +86,7 @@ func resourceGCSArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	if err := uploadArtifact(config, d, a); err != nil {
-		return err
-	}
-
-	d.SetId(a.name)
-	return nil
+	return uploadArtifact(config, d, a)
 }
 
 func loadGCSArtifact(ctx context.Context, d *schema.ResourceData, storageClient *storage.Client) (*artifact, error) {

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -90,10 +90,6 @@ type artifactConfig struct {
 }
 
 func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
-	// An artifact with the same name and version can be uploaded multiple times
-	// without error. Because of this, there is no need to do partial state
-	// management to account for the facdt that setting properties may fail
-	// because uploading a jar can occur multiple times without error.
 	config := m.(*Config)
 	a, err := loadLocalArtifact(d)
 	if err != nil {
@@ -102,20 +98,20 @@ func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	if err := uploadArtifact(config, d, a); err != nil {
 		return err
 	}
-	d.SetId(a.name)
 	return nil
 }
 
-func uploadArtifact(config *Config, rd *schema.ResourceData, a *artifact) error {
-	addr := urlJoin(config.host, "/v3/namespaces", rd.Get("namespace").(string), "/artifacts", a.name)
+func uploadArtifact(config *Config, d *schema.ResourceData, a *artifact) error {
+	addr := urlJoin(config.host, "/v3/namespaces", d.Get("namespace").(string), "/artifacts", a.name)
 
 	if err := uploadJar(config.httpClient, addr, a); err != nil {
 		return err
 	}
+	d.SetId(a.name)
+
 	if err := uploadProps(config.httpClient, addr, a); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -95,10 +95,7 @@ func resourceLocalArtifactCreate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := uploadArtifact(config, d, a); err != nil {
-		return err
-	}
-	return nil
+	return uploadArtifact(config, d, a)
 }
 
 func uploadArtifact(config *Config, d *schema.ResourceData, a *artifact) error {


### PR DESCRIPTION
It is possible for the artifact to be created but the properties upload to fail. In this case on a retry the create will keep failing.

The right way to fix this is to set ID after the artifact is created. Then any following errors will taint the resource, which will first call destroy then create a new artifact.

Fix #73