### PR TITLE
Don't authenticate storage client

### DIFF
--- a/cdap/provider.go
+++ b/cdap/provider.go
@@ -75,7 +75,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 	}
 	httpClient.Timeout = 5 * time.Minute
 
-	storageClient, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadOnly))
+	storageClient, err := storage.NewClient(ctx, option.WithScopes(storage.ScopeReadOnly), option.WithoutAuthentication())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This storage client is used for reading GCS hub artifacts which should be public buckets, thus we don't need to authenticate for this.

Fix #81