### PR TITLE
updated delete namespace URL to /v3/unrecoverable/namespaces per the docs

### DIFF
--- a/cdap/resource_namespace.go
+++ b/cdap/resource_namespace.go
@@ -65,7 +65,7 @@ func resourceNamespaceRead(d *schema.ResourceData, m interface{}) error {
 func resourceNamespaceDelete(d *schema.ResourceData, m interface{}) error {
 	config := m.(*Config)
 	name := d.Get("name").(string)
-	addr := urlJoin(config.host, "/v3/namespaces", name)
+	addr := urlJoin(config.host, "/v3/unrecoverable/namespaces", name)
 
 	req, err := http.NewRequest(http.MethodDelete, addr, nil)
 	if err != nil {


### PR DESCRIPTION
Helps fix the 405 error reported from #83 assuming `{"enable.unrecoverable.reset" = "true"}` is already set on the instance.