### PR TITLE
Bump go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-cdap
 
-go 1.16
+go 1.18
 
 require (
 	cloud.google.com/go/storage v1.29.0


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/terraform-provider-cdap/pull/144 is failing due to the outdated go version.