### PR TITLE
CDAP-21239 : Adding support to upload JDBC driver from local file

### DIFF
--- a/cdap/provider.go
+++ b/cdap/provider.go
@@ -53,6 +53,7 @@ func Provider(version string) *schema.Provider {
 			"cdap_streaming_program_run": resourceStreamingProgramRun(),
 			"cdap_gcs_artifact":          resourceGCSArtifact(),
 			"cdap_local_artifact":        resourceLocalArtifact(),
+			"cdap_local_jdbc_driver":     resourceJDBCDriver(),
 			"cdap_namespace":             resourceNamespace(),
 			"cdap_namespace_preferences": resourceNamespacePreferences(),
 			"cdap_profile":               resourceProfile(),

--- a/cdap/resource_local_artifact.go
+++ b/cdap/resource_local_artifact.go
@@ -113,17 +113,15 @@ func uploadArtifact(config *Config, d *schema.ResourceData, a *artifact) error {
 }
 
 func uploadJar(config *Config, addr string, a *artifact) error {
-	req, err := http.NewRequest(http.MethodPost, addr, bytes.NewReader(a.jar))
-	if err != nil {
-		return err
+	headers := map[string]string{
+		"Artifact-Version": a.version,
 	}
-	req.Header = map[string][]string{}
-	req.Header.Add("Artifact-Version", a.version)
-	req.Header.Add("Artifact-Extends", strings.Join(a.config.Parents, "/"))
-	if _, err := httpCall(config, req); err != nil {
-		return err
+
+	if a.config != nil {
+		headers["Artifact-Extends"] = strings.Join(a.config.Parents, "/")
 	}
-	return nil
+
+	return uploadPluginJar(config, addr, a.jar, headers)
 }
 
 func uploadProps(config *Config, artifactAddr string, a *artifact) error {
@@ -227,4 +225,19 @@ func artifactExists(config *Config, name, namespace string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func uploadPluginJar(config *Config, addr string, jarBytes []byte, headers map[string]string) error {
+	req, err := http.NewRequest(http.MethodPost, addr, bytes.NewReader(jarBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header = map[string][]string{}
+	for k, v := range headers {
+		req.Header.Add(k, v)
+	}
+
+	_, err = httpCall(config, req)
+	return err
 }

--- a/cdap/resource_local_jdbcdriver.go
+++ b/cdap/resource_local_jdbcdriver.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdap
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceJDBCDriver() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceJDBCDriverCreate,
+		Read:   resourceLocalArtifactRead,   // Reusing existing read logic
+		Delete: resourceLocalArtifactDelete, // Reusing existing delete logic
+		Exists: resourceLocalArtifactExists, // Reusing existing existence check
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the artifact.",
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of the namespace in which this resource belongs. If not provided, the default namespace is used.",
+				DefaultFunc: func() (interface{}, error) {
+					return defaultNamespace, nil
+				},
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The version of the artifact.",
+			},
+			"jar_binary_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The local path to the JAR binary for the artifact.",
+			},
+			"archive_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The archive name header (e.g., mysql-connector-java).",
+			},
+			"plugins": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "List of plugins to declare in the artifact headers.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"class_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceJDBCDriverCreate(d *schema.ResourceData, m interface{}) error {
+	config := m.(*Config)
+	namespace := d.Get("namespace").(string)
+	name := d.Get("name").(string)
+	version := d.Get("version").(string)
+	jarPath := d.Get("jar_binary_path").(string)
+
+	jarBytes, err := ioutil.ReadFile(jarPath)
+	if err != nil {
+		return err
+	}
+
+	// 2. Build the necessary headers
+	headers := map[string]string{
+		"Content-Type":     "application/java-archive",
+		"Artifact-Version": version,
+	}
+
+	if archiveName, ok := d.GetOk("archive_name"); ok {
+		headers["x-archive-name"] = archiveName.(string)
+	}
+
+	if pluginsJsonStr, ok := d.GetOk("plugins"); ok {
+		pluginList := pluginsJsonStr.([]interface{})
+		var plugins []map[string]string
+
+		for _, p := range pluginList {
+			pMap := p.(map[string]interface{})
+			plugin := map[string]string{
+				"name":      pMap["name"].(string),
+				"type":      pMap["type"].(string),
+				"className": pMap["class_name"].(string),
+			}
+
+			if desc, ok := pMap["description"]; ok && desc.(string) != "" {
+				plugin["description"] = desc.(string)
+			}
+
+			plugins = append(plugins, plugin)
+		}
+
+		pluginsJSON, err := json.Marshal(plugins)
+		if err != nil {
+			return err
+		}
+		headers["artifact-plugins"] = string(pluginsJSON)
+	}
+
+	addr := urlJoin(config.host, "/v3/namespaces", namespace, "/artifacts", name)
+
+	if err := uploadPluginJar(config, addr, jarBytes, headers); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+	return nil
+}


### PR DESCRIPTION
### Adding support to upload JDBC driver 

Changes : 

1. Making the Upload Jar function generic, which can take any headers in existing `resource_local_artifact.go`
2. Adding `resource_local_jdbcdriver.go` , which builds the request for uploading driver. 

### Testing JDBC upload : 

```
resource "cdap_local_jdbc_driver" "test" {
  name            = "mysql-connector-j"
  version         = "8.0.25"
  jar_binary_path = "/usr/local/ABC/mysql-connector-java-8.0.25.jar"
  archive_name    = "mysql-connector-java"

  plugins {
    name        = "mysql-8.0.25"
    type        = "jdbc"
    class_name  = "com.mysql.jdbc.Driver"
    description = "Plugin for the MySQL JDBC driver"
  }
}



cdap_local_jdbc_driver.test: Creating...
cdap_local_jdbc_driver.test: Still creating... [10s elapsed]
cdap_local_jdbc_driver.test: Creation complete after 17s [id=mysql-connector-j]
```

- Was able to see DRIVER in UI 

### Testing normal plugin upload 

```
resource "cdap_gcs_artifact" "example_gcs_artifact" {
  name             = "datagen-plugins"
  version          = "0.1.0-SNAPSHOT."
  namespace        = "default"

  jar_binary_path  = "gs://ABC/datagen_plugin/datagen-plugins-0.1.0-SNAPSHOT.jar"
  json_config_path = "gs://ABC/datagen_plugin/datagen-plugins-0.1.0-SNAPSHOT.json"
}


cdap_gcs_artifact.example_gcs_artifact: Creating...
cdap_gcs_artifact.example_gcs_artifact: Still creating... [10s elapsed]
cdap_gcs_artifact.example_gcs_artifact: Still creating... [20s elapsed]
cdap_gcs_artifact.example_gcs_artifact: Creation complete after 27s [id=datagen-plugins]
```

- Was able to see Plugin in UI 
