### PR TITLE
Support preserving client credentials when deleting an OAuth provider

### DIFF
--- a/cdap/resource_oauth.go
+++ b/cdap/resource_oauth.go
@@ -85,6 +85,12 @@ func resourceOAuthProvider() *schema.Resource {
 				Default:     false,
 				Description: "Whether to reuse existing client credentials if they exist.",
 			},
+			"preserve_client_credentials": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to preserve existing client credentials when deleting the provider.",
+			},
 		},
 	}
 }
@@ -141,9 +147,21 @@ func resourceOAuthProviderUpdate(d *schema.ResourceData, m interface{}) error {
 func resourceOAuthProviderDelete(d *schema.ResourceData, m interface{}) error {
 	config := m.(*Config)
 	name := d.Id()
-	addr := urlJoin(config.host, oauthProviderBasePath, name)
+	preserve := d.Get("preserve_client_credentials").(bool)
 
-	req, err := http.NewRequest(http.MethodDelete, addr, nil)
+	addr := urlJoin(config.host, oauthProviderBasePath, name)
+	addrURL, err := url.Parse(addr)
+	if err != nil {
+		return fmt.Errorf("failed to parse base URL: %v", err)
+	}
+
+	if preserve {
+		q := addrURL.Query()
+		q.Set("preserve_client_credentials", "true")
+		addrURL.RawQuery = q.Encode()
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, addrURL.String(), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Only merge after : https://github.com/cdapio/cdap/pull/16169 

### Testing : 

- 1st test with creating a provider with `preserve_client_credentials = true` and `reuse_client_credentials    = false`  , so it stored the credentials , and then delete

```
resource "cdap_oauth_provider" "test_oauth_preserve" {
  name                        = "test_oauth_preserve"
  client_id                   = "test-client-id-1"
  client_secret               = "test-client-secret-1"
  login_url                   = "https://example.com/oauth2/v2/login"
  token_refresh_url           = "https://example.com/oauth2/v2/refresh"
  reuse_client_credentials    = false
  preserve_client_credentials = true
}
```
```
terraform init
terraform apply
terraform destroy
```
All success. 

- Now create provider with same NAME , but with  `reuse_client_credentials    = true` 
```
resource "cdap_oauth_provider" "test_oauth_preserve" {
  name                        = "test_oauth_preserve"
  login_url                   = "https://example.com/oauth2/v2/login"
  token_refresh_url           = "https://example.com/oauth2/v2/refresh"
  reuse_client_credentials    = false
  preserve_client_credentials = true
}
```
```
terraform init
terraform apply
terraform destroy
```
Success. 

If credentials were not preserved from 1st test, it would have failed. 
